### PR TITLE
Create account_map and account_map_enabled variables

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -13,10 +13,17 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 module "allowed_role_map" {
-  source = "../account-map/modules/roles-to-principals"
+  source = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/roles-to-principals?ref=v1.536.1"
 
   privileged = false
   role_map   = var.allowed_roles
+
+  tenant      = var.account_map_enabled ? module.iam_roles.global_tenant_name : null
+  environment = var.account_map_enabled ? module.iam_roles.global_environment_name : null
+  stage       = var.account_map_enabled ? module.iam_roles.global_stage_name : null
+
+  account_map_bypass   = !var.account_map_enabled
+  account_map_defaults = var.account_map
 
   context = module.this.context
 }
@@ -56,23 +63,27 @@ data "aws_iam_policy_document" "key_policy" {
     }
   }
 
-  statement {
-    sid    = "KeyUsage"
-    effect = "Allow"
+  # Only create the "KeyUsage" statement if there are any principals
+  dynamic "statement" {
+    for_each = length(local.principals) > 0 ? [1] : []
+    content {
+      sid    = "KeyUsage"
+      effect = "Allow"
 
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey",
-    ]
+      actions = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
 
-    resources = ["*"]
+      resources = ["*"]
 
-    principals {
-      type        = "AWS"
-      identifiers = local.principals
+      principals {
+        type        = "AWS"
+        identifiers = local.principals
+      }
     }
   }
 

--- a/src/variables-account-map.tf
+++ b/src/variables-account-map.tf
@@ -1,0 +1,25 @@
+variable "account_map_enabled" {
+  type        = bool
+  description = "INFO: Temporary variable required for account-map deprication plan. Please do not change the value"
+  default     = true
+}
+
+variable "account_map" {
+  type = object({
+    full_account_map              = map(string)
+    audit_account_account_name    = optional(string, "")
+    root_account_account_name     = optional(string, "")
+    identity_account_account_name = optional(string, "")
+    aws_partition                 = optional(string, "aws")
+    iam_role_arn_templates        = optional(map(string), {})
+  })
+  description = "INFO: Temporary variable required for account-map deprication plan. Please do not change the value"
+  default = {
+    full_account_map              = {}
+    audit_account_account_name    = ""
+    root_account_account_name     = ""
+    identity_account_account_name = ""
+    aws_partition                 = "aws"
+    iam_role_arn_templates        = {}
+  }
+}

--- a/src/variables-account-map.tf
+++ b/src/variables-account-map.tf
@@ -1,6 +1,6 @@
 variable "account_map_enabled" {
   type        = bool
-  description = "INFO: Temporary variable required for account-map deprication plan. Please do not change the value"
+  description = "INFO: Temporary variable required for account-map deprecation plan. Please do not change the value"
   default     = true
 }
 
@@ -13,7 +13,7 @@ variable "account_map" {
     aws_partition                 = optional(string, "aws")
     iam_role_arn_templates        = optional(map(string), {})
   })
-  description = "INFO: Temporary variable required for account-map deprication plan. Please do not change the value"
+  description = "INFO: Temporary variable required for account-map deprecation plan. Please do not change the value"
   default = {
     full_account_map              = {}
     audit_account_account_name    = ""


### PR DESCRIPTION
## what
* Added temporary variables for `account-map` deprecation plan.
* Fix "KeyUsage" statement
* Use the `roles-to-principals` module by reference

## why
* Part of `account-map` depreciation plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable account mapping for multi-account AWS setups, including audit/root/identity account names, AWS partition, and IAM role template customization.
  * Account mapping can be enabled or disabled via configuration.

* **Bug Fixes / Behavior Changes**
  * Key policy statements now are included conditionally—usage and extra statements are only added when relevant principals or custom statements exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->